### PR TITLE
SerializableDeviceRange: Add parameterless constructor

### DIFF
--- a/AnalogGridControl/Util/SerializableDeviceRange.cs
+++ b/AnalogGridControl/Util/SerializableDeviceRange.cs
@@ -14,6 +14,8 @@ namespace AnanaceDev.AnalogGridControl.Util
     public int? RangeMin { get; set; }
     public int? RangeMax { get; set; }
 
+    private SerializableDeviceRange() { }
+
     public SerializableDeviceRange(DeviceAxis axis, InputRange range)
     {
       Axis = axis;


### PR DESCRIPTION
Add a parameterless constructor to SerializableDeviceRange.
This seems to be necessary for the `IXmlSerializable` interface to be usable by the XML serialization / deserialization for this plugin's config files.

With these changes, config files can be loaded and saved without error, and the resulting "corrupted" config file copy resulting from it.