### PR TITLE
Support controlling camera through analog axis

### DIFF
--- a/AnalogGridControl/AnalogGridControlSession.cs
+++ b/AnalogGridControl/AnalogGridControlSession.cs
@@ -23,6 +23,7 @@ namespace AnanaceDev.AnalogGridControl
     public bool IsAnalogInputActive => Input.IsAnalogInputActive;
     public Vector3 MovementVector => Input.MovementVector;
     public Vector3 RotationVector => Input.RotationVector;
+    public Vector2 CameraRotationVector => Input.CameraRotationVector;
     public float BrakeForce => Input.BrakeForce;
     public float AccelForce => Math.Max(Input.MovementVector.Z + Input.AccelForce, 1f);
 
@@ -251,6 +252,9 @@ namespace AnanaceDev.AnalogGridControl
               !AnalogEmulation.ShouldTick(AccelForce * 2, CurrentTick));
         }
       }
+
+      IMyCameraController cameraController = MyAPIGateway.Session?.CameraController;
+      cameraController.Rotate(CameraRotationVector, 0f);
     }
 
 #region Networking

--- a/AnalogGridControl/AnalogGridControlSession.cs
+++ b/AnalogGridControl/AnalogGridControlSession.cs
@@ -254,7 +254,7 @@ namespace AnanaceDev.AnalogGridControl
       }
 
       IMyCameraController cameraController = MyAPIGateway.Session?.CameraController;
-      cameraController.Rotate(CameraRotationVector, 0f);
+      cameraController?.Rotate(CameraRotationVector, 0f);
     }
 
 #region Networking

--- a/AnalogGridControl/InputAggregate.cs
+++ b/AnalogGridControl/InputAggregate.cs
@@ -42,11 +42,13 @@ namespace AnanaceDev.AnalogGridControl
     
     public Vector3 _MovementVector = Vector3.Zero;
     public Vector3 _RotationVector = Vector3.Zero;
+    public Vector2 _CameraRotationVector = Vector2.Zero;
     public float _AccelForce = 0;
     public float _BrakeForce = 0;
 
     public Vector3 MovementVector => _MovementVector;
     public Vector3 RotationVector => _RotationVector;
+    public Vector2 CameraRotationVector => _CameraRotationVector;
     public float AccelForce => _BrakeForce;
     public float BrakeForce => _BrakeForce;
 
@@ -97,6 +99,7 @@ namespace AnanaceDev.AnalogGridControl
 
       _MovementVector = Vector3.Zero;
       _RotationVector = Vector3.Zero;
+      _CameraRotationVector = Vector2.Zero;
       _BrakeForce = 0;
       _AccelForce = 0;
     }
@@ -137,9 +140,13 @@ namespace AnanaceDev.AnalogGridControl
                 break;
 
               // Pitch in SE is inverted compared to how joysticks usually handle it
-              case GameAxis.TurnPitch: value = (value - 0.5f) * -40; break;
+              case GameAxis.TurnPitch: 
+              case GameAxis.CameraPitch:
+                value = (value - 0.5f) * -40; 
+                break;
               case GameAxis.TurnYaw:
               case GameAxis.TurnRoll:
+              case GameAxis.CameraYaw:
                 value = (value - 0.5f) * 40;
                 break;
             }
@@ -157,6 +164,9 @@ namespace AnanaceDev.AnalogGridControl
               case GameAxis.TurnPitch: _RotationVector.X = Math.Abs(value) > Math.Abs(_RotationVector.X) ? value : _RotationVector.X; break;
               case GameAxis.TurnYaw: _RotationVector.Y = Math.Abs(value) > Math.Abs(_RotationVector.Y) ? value : _RotationVector.Y; break;
               case GameAxis.TurnRoll: _RotationVector.Z = Math.Abs(value) > Math.Abs(_RotationVector.Z) ? value : _RotationVector.Z; break;
+              
+              case GameAxis.CameraPitch: _CameraRotationVector.X = Math.Abs(value) > Math.Abs(_CameraRotationVector.X) ? value : _CameraRotationVector.X; break;
+              case GameAxis.CameraYaw: _CameraRotationVector.Y = Math.Abs(value) > Math.Abs(_CameraRotationVector.Y) ? value : _CameraRotationVector.Y; break;
             }
           }
 

--- a/AnalogGridControl/InputMapping/GameAxis.cs
+++ b/AnalogGridControl/InputMapping/GameAxis.cs
@@ -26,7 +26,12 @@ namespace AnanaceDev.AnalogGridControl.InputMapping
     [EnumDescription("Yaw")]
     TurnYaw,
     [EnumDescription("Roll")]
-    TurnRoll
+    TurnRoll,
+
+    [EnumDescription("Camera Pitch")]
+    CameraPitch,
+    [EnumDescription("Camera Yaw")]
+    CameraYaw
   }
 
   public static class GameAxisExtensions
@@ -45,6 +50,8 @@ namespace AnanaceDev.AnalogGridControl.InputMapping
       case GameAxis.TurnPitch:
       case GameAxis.TurnYaw:
       case GameAxis.TurnRoll:
+      case GameAxis.CameraPitch:
+      case GameAxis.CameraYaw:
         return DeadzonePoint.Mid;
       }
 


### PR DESCRIPTION
Add two axis for controlling the camera in third person view when seated in a cockpit

- `GameAxis.CameraPitch`
- `GameAxis.CameraPitch`

Inputs to these axis are sent to the Sesson's CameraController as a (2D) rotation matrix.

I have yet to find a good way to do camera zoom controls.

---

I thought being able to control the camera on my stick's ministick would be useful, so I went ahead and added support.
I've been running this code for about 2~3 weeks at this point, and am fairly confident that it'll just work.